### PR TITLE
fix: CGPA input field is changed to number type from any text type

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                             </div>
                             <div class="field">
                                 <b><p>CGPA (OR PERCENTAGE)</p></b>
-                                <input type="text" class="inp" id="marks" name="marks" placeholder="Enter here">
+                                <input type="number" class="inp" id="marks" name="marks" placeholder="Enter here">
                             </div>
                             <div class="field">
                                 <b><p>GRADUATION DATE (OR EXPECTED GRADUATION DATE)</p></b>

--- a/style.css
+++ b/style.css
@@ -413,3 +413,10 @@ ul{
 .chColor3{
     color: #555555;
 }
+
+/* Hide the number input spinner for all browsers */
+input[type=number]::-webkit-inner-spin-button, 
+input[type=number]::-webkit-outer-spin-button { 
+    -webkit-appearance: none; 
+    margin: 0; 
+}


### PR DESCRIPTION
As mentioned in the issue no #1, I've changed the input type of the CGPA ( or Percentage ) input field from 'text' to 'number'. 
Additionally, added some css code to remove the increase decrease buttons inside the number input field.

Kindly review and merge the Pull Request.
Thank You.

@SattikBhowmick25 